### PR TITLE
Changed the way how laser parameters are acquired from layer names...

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,6 @@ Found that raster optimisation code seems to be changing the pixel data at the e
 Added option to the menu for users to disable raster optimisations.
 
 05-February-2016 - Added support for LinuxCNC based lasers and Air Assist option.
+
+8-February-2016 - Changed the way how laser parameters are acquired from the layer name. You can use descriptive names for layers with the params (power or p, ppm, feed or f). If some parameter is missing, a default value is used. Spaces are allowed in the args list.
+The following 5 formats (without quotes) are recognized: "LayerName" -- just a descriptive name, get all default values from dialog box. "42" -- just a power setting, rest using defaults. "42 [feed=123]" -- power and feed. "[power=42, f=123]" -- power and feed. "LayerName [p=42, f=123]" -- descriptive name, power and feed.

--- a/turnkeylaser.inx
+++ b/turnkeylaser.inx
@@ -23,12 +23,16 @@
 
 You're able to specify in your layer names the laser power output, feedrate and optionally the pulse per millimetre option for pulsed lasing mode as opposed to the default continuous wave operation mode.
 
-1)Name your layer like the following example :
-35 [feed=600,ppm=40]
-2)Draw your designs and group them based on lasing options in the layer name.
-3)Select the paths you want to export, then run this script.
+1) Name your layer in one the following ways:
+    LayerName -- name, default values from dialog box
+    35 -- power, rest using defaults
+    35 [feed=600, ppm=40] -- power, feed and ppm
+    [power=35, f=600] -- power and feed
+    LayerName [p=35, f=600] -- name, power and feed
+2) Draw your designs and group them based on lasing options in the layer name. Layers are read from top to bottom.
+3) Select the paths you want to export, then run this script.
 
-In the example above the layer will be cut at 35% power with a feedrate of 600mm per minute and a pulse rate of 40 pulses per millimetre (at 60ms pulses).
+In the example above the layer will be cut at 35% power with a feedrate of 600mm per minute (and possibly with a pulse rate of 40 pulses per millimetre, at 60ms pulses).
 
 If the ppm option isn't specified in the layer options then output lines will be cut in continuous wave mode at the power and feed specified.
 If you do not specify the laser power or other options in the layer name then they will default to the options in the export dialog box under "Preferences".

--- a/turnkeylaser.py
+++ b/turnkeylaser.py
@@ -422,7 +422,7 @@ def parse_layer_name(txt):
                 (field, value) = arg.split("=")
             except:
                 raise ValueError("Invalid argument in layer '%s'" % layerName)
-            if (field == "feed" or field == "ppm"):
+            if (field == "feed" or field == "f" or field == "ppm" or field == "power" or field == "p"):
                 try:
                     value = float(value)
                 except:
@@ -1173,8 +1173,15 @@ class Gcode_tools(inkex.Effect):
                 return
 
             # Check if the layer specifies an alternative (from the default) feed rate
-            altfeed = layerParams.get("feed", self.options.feed)
+            if (layerParams.get("f", None)):
+                altfeed = layerParams.get("f", self.options.feed)
+            else:
+                altfeed = layerParams.get("feed", self.options.feed)
             altppm = layerParams.get("ppm", None)
+            if (layerParams.get("p", None)):
+                laserPower = layerParams.get("p", None)
+            else:
+                laserPower = layerParams.get("power", None)
 
             logger.write("layer %s" % layerName)
             if (layerParams):
@@ -1215,16 +1222,17 @@ class Gcode_tools(inkex.Effect):
             #Determind the power of the laser that this layer should be cut at.
             #If the layer is not named as an integer value then default to the laser intensity set at the export settings.
             #Fetch the laser power from the export dialog box.
-            laserPower = self.options.laser
-
-            try:
-                if (int(layerName) > 0 and int(layerName) <= 100):
-                    laserPower = int(layerName)
-                else :
-                    laserPower = self.options.laser
-            except ValueError,e:
+            if (not laserPower):
                 laserPower = self.options.laser
-                inkex.errormsg("Unable to parse power level for layer name. Using default power level %d percent." % (self.options.laser))
+
+                try:
+                    if (int(layerName) > 0 and int(layerName) <= 100):
+                        laserPower = int(layerName)
+                    else :
+                        laserPower = self.options.laser
+                except ValueError,e:
+                    laserPower = self.options.laser
+                    inkex.errormsg("Unable to parse power level for layer name. Using default power level %d percent." % (self.options.laser))
 
 
 
@@ -1304,14 +1312,15 @@ class Gcode_tools(inkex.Effect):
                     #Fetch the laser power from the export dialog box.
                     laserPower = self.options.laser
 
-                    try:
-                        if (int(layerName) > 0 and int(layerName) <= 100):
-                            laserPower = int(layerName)
-                        else :
+                    if (not laserPower):
+                        try:
+                            if (int(layerName) > 0 and int(layerName) <= 100):
+                                laserPower = int(layerName)
+                            else :
+                                laserPower = self.options.laser
+                        except ValueError,e:
                             laserPower = self.options.laser
-                    except ValueError,e:
-                        laserPower = self.options.laser
-                        inkex.errormsg("Unable to parse power level for layer name. Using default power level %d percent." % (self.options.laser))
+                            inkex.errormsg("Unable to parse power level for layer name. Using default power level %d percent." % (self.options.laser))
 
                     #Switch between smoothie power levels and ramps+marlin power levels
                     #ramps and marlin expect 0 to 100 while smoothie wants 0.0 to 1.0


### PR DESCRIPTION
…because I want to use descriptive names. 5 formats are supported now.
